### PR TITLE
Update moecs license to MIT (from GPLv3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A curated list of awesome Odin libraries, software and resources.
 | [libretro](https://codeberg.org/virtualxt/libretro) | Simple API that allows for the creation of games and emulators | [MIT](https://codeberg.org/virtualxt/libretro/src/branch/main/LICENSE) | Gamedev, Emulation
 | [muninn](https://github.com/GuilHartt/muninn) | A lightweight, high-performance, archetype-based Entity Component System (ECS) | [zlib](https://github.com/GuilHartt/muninn/blob/main/LICENSE) | Gamedev, ECS, Performance
 | [odecs](https://github.com/NateTheGreatt/odecs) | A simple, modern ECS built in Odin. | [MIT](https://github.com/NateTheGreatt/odecs/blob/main/license) | Gamedev, ECS
-| [moecs](https://github.com/helioscout/moecs) | Easy to use **mo**tivated **e**ntity **c**omponent **s**ystem. | [GPL-3.0](https://github.com/helioscout/moecs/blob/master/LICENSE.md) | Gamedev, ECS
+| [moecs](https://github.com/helioscout/moecs) | Easy to use **mo**tivated **e**ntity **c**omponent **s**ystem. | [MIT](https://github.com/helioscout/moecs/blob/master/LICENSE.md) | Gamedev, ECS
 | [Odin Unity Interop](https://github.com/herohiralal/com.herohiralal.odininterop) | Odin interoperability for Unity. Works with Windows, Mac, Linux, iOS, Android. Super-easy to generate C# bindings, and the package already ships with a lot of necessary ones. | [Apache 2.0](https://github.com/herohiralal/com.herohiralal.odininterop/blob/main/LICENSE) | GameDev, Unity, Engine, Utility
 | [Marshmallow engine](https://github.com/DragosPopse/marshmallow) | WIP Game Engine written in pure Odin | None | Gamedev, Engine
 


### PR DESCRIPTION
As of the most recent commit to moecs: https://github.com/helioscout/moecs/commit/2d5ef3581c7a59c1a8a12d9fc5597ee3d0dc6743 it is no longer GPLv3 licensed, instead using the MIT license. 